### PR TITLE
Add weekly report API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,3 +53,14 @@ jobs:
       - name: backup logging
         if: ${{ failure() }}
         run: echo backup Remain 
+  weekly-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger weekly report
+        uses: boyeborg/fetch-url-action@v1.1
+        with:
+          url: https://myhome-apply.vercel.app/api/report/weekly?category=APT
+          run: echo "run weekly report"
+      - name: backup logging
+        if: ${{ failure() }}
+        run: echo backup weekly report

--- a/server/api/report/weekly.get.ts
+++ b/server/api/report/weekly.get.ts
@@ -1,0 +1,32 @@
+import { defineEventHandler, getQuery } from 'h3';
+import moment from 'moment';
+import { Home } from '~/server/model/schemas/Home.schema';
+
+export default defineEventHandler(async (event) => {
+  const { category = 'APT' } = getQuery(event);
+
+  const start = moment().startOf('week').format('YYYY-MM-DD');
+  const end = moment().endOf('week').add(1, 'day').format('YYYY-MM-DD');
+
+  let list;
+  if (category === 'APT') {
+    list = await Home.find({
+      CATEGORY: category,
+      RCEPT_BGNDE: { $gte: new Date(start), $lt: new Date(end) }
+    });
+  } else {
+    list = await Home.find({
+      CATEGORY: category,
+      SUBSCRPT_RCEPT_BGNDE: { $gte: new Date(start), $lt: new Date(end) }
+    });
+  }
+
+  const htmlList = '<ul>' +
+    list.map((item:any) => {
+      const date = item.RCEPT_BGNDE || item.SUBSCRPT_RCEPT_BGNDE;
+      return `<li>${item.HOUSE_NM} - ${moment(date).format('YYYY-MM-DD')}</li>`;
+    }).join('') + '</ul>';
+
+  event.node.res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  return htmlList;
+});

--- a/tests/weeklyReport.test.ts
+++ b/tests/weeklyReport.test.ts
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals'
+import handler from '../server/api/report/weekly.get'
+import { Home } from '../server/model/schemas/Home.schema'
+
+jest.mock('../server/model/schemas/Home.schema')
+
+const mockRes = { setHeader: jest.fn() }
+
+describe('weekly report handler', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns html list', async () => {
+    const date = new Date()
+    ;(Home.find as jest.Mock).mockResolvedValue([
+      { HOUSE_NM: 'Test A', RCEPT_BGNDE: date },
+      { HOUSE_NM: 'Test B', RCEPT_BGNDE: date }
+    ])
+
+    const html = await handler({ node: { res: mockRes } } as any)
+    expect(html).toContain('<ul>')
+    expect(html).toContain('Test A')
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8')
+  })
+})


### PR DESCRIPTION
## issue
- [링크](https://github.com/RumbleKAT/myhome-apply/issues/14)

## Summary
- add HTML weekly report endpoint
- trigger weekly report via GitHub Actions
- test HTML response generation

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841ab2475a4832d8ac318455a455786